### PR TITLE
Add Synthea Module for CMS122 measure

### DIFF
--- a/src/main/resources/keep_modules/keep_IPP.json
+++ b/src/main/resources/keep_modules/keep_IPP.json
@@ -1,0 +1,32 @@
+{
+  "name": "keep_IPP",
+  "remarks": [
+    "Initial Population Keep Module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "transition": "Keep",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "ecqm_ipp",
+            "operator": "==",
+            "value": true
+          }
+        },
+        {
+          "transition": "Terminal"
+        }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Keep": {
+      "type": "Terminal"
+    }
+  },
+  "gmf_version": 2
+}

--- a/src/main/resources/keep_modules/keep_denom.json
+++ b/src/main/resources/keep_modules/keep_denom.json
@@ -1,0 +1,32 @@
+{
+  "name": "keep_denom",
+  "remarks": [
+    "Denominator Population Keep Module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "transition": "Keep",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "ecqm_denominator",
+            "operator": "==",
+            "value": true
+          }
+        },
+        {
+          "transition": "Terminal"
+        }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Keep": {
+      "type": "Terminal"
+    }
+  },
+  "gmf_version": 2
+}

--- a/src/main/resources/keep_modules/keep_numer.json
+++ b/src/main/resources/keep_modules/keep_numer.json
@@ -1,0 +1,32 @@
+{
+  "name": "keep_numer",
+  "remarks": [
+    "Numerator Population Keep Module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "transition": "Keep",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "ecqm_numerator",
+            "operator": "==",
+            "value": true
+          }
+        },
+        {
+          "transition": "Terminal"
+        }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Keep": {
+      "type": "Terminal"
+    }
+  },
+  "gmf_version": 2
+}

--- a/src/main/resources/modules/CMS122-v10.json
+++ b/src/main/resources/modules/CMS122-v10.json
@@ -123,13 +123,13 @@
         {
           "system": "http://www.ama-assn.org/go/cpt",
           "code": "99397",
-          "display": "",
+          "display": "Preventive Care Services - Established Office Visit, 18 and Up",
           "value_set": ""
         },
         {
           "system": "http://www.ama-assn.org/go/cpt",
           "code": "99387",
-          "display": "",
+          "display": "Preventive Care Services-Initial Office Visit, 18 and Up",
           "value_set": ""
         },
         {

--- a/src/main/resources/modules/CMS122-v10.json
+++ b/src/main/resources/modules/CMS122-v10.json
@@ -88,7 +88,6 @@
     "IPP_Qualifying_Encounter": {
       "type": "Encounter",
       "telemedicine_possibility": "none",
-      "direct_transition": "Set_IPP",
       "name": "IPP_Qualifying_Encounter",
       "codes": [
         {
@@ -128,23 +127,19 @@
           "value_set": ""
         }
       ],
-      "encounter_class": "inpatient"
+      "encounter_class": "inpatient",
+      "distributed_transition": [
+        {
+          "transition": "Record_HbA1c",
+          "distribution": 0.75
+        },
+        {
+          "transition": "Set_HbA1c_Not_Performed",
+          "distribution": 0.25
+        }
+      ]
     },
-    "Set_IPP": {
-      "type": "SetAttribute",
-      "attribute": "ecqm_ipp",
-      "direct_transition": "Set_Denominator",
-      "value": true,
-      "name": "Set_IPP"
-    },
-    "Set_Denominator": {
-      "type": "SetAttribute",
-      "attribute": "ecqm_denominator",
-      "value": true,
-      "direct_transition": "Record_HbA1C",
-      "name": "Set_Denominator"
-    },
-    "Record_HbA1C": {
+    "Record_HbA1c": {
       "type": "Observation",
       "vital_sign": "Blood Glucose",
       "category": "laboratory",
@@ -169,8 +164,59 @@
         }
       ],
       "unit": "%",
+      "name": "Record_HbA1c",
+      "conditional_transition": [
+        {
+          "transition": "Set_Numerator",
+          "condition": {
+            "condition_type": "Or",
+            "conditions": [
+              {
+                "condition_type": "Attribute",
+                "attribute": "Blood Glucose",
+                "operator": ">=",
+                "value": 9
+              },
+              {
+                "condition_type": "Attribute",
+                "attribute": "Blood Glucose",
+                "operator": "is nil"
+              }
+            ]
+          }
+        },
+        {
+          "transition": "Set_Denominator"
+        }
+      ]
+    },
+    "Set_HbA1c_Not_Performed": {
+      "type": "SetAttribute",
+      "attribute": "HbA1c_not_performed",
+      "direct_transition": "Set_Numerator",
+      "name": "Set_HbA1c_Not_Performed",
+      "value": true
+    },
+    "Set_Numerator": {
+      "type": "SetAttribute",
+      "attribute": "ecqm_numerator",
+      "direct_transition": "Set_Denominator",
+      "value": true,
+      "name": "Set_Numerator"
+    },
+    "Set_Denominator": {
+      "type": "SetAttribute",
+      "attribute": "ecqm_denominator",
+      "direct_transition": "Set_IPP",
+      "value": true,
+      "name": "Set_Denominator"
+    },
+    "Set_IPP": {
+      "type": "SetAttribute",
+      "attribute": "ecqm_ipp",
       "direct_transition": "Terminal",
-      "name": "Record_HA1C"
+      "value": true,
+      "name": "Set_IPP"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/CMS122-v10.json
+++ b/src/main/resources/modules/CMS122-v10.json
@@ -6,8 +6,8 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Set_Measurement_Period_Start",
-      "name": "Initial"
+      "name": "Initial",
+      "direct_transition": "IPP_Age_Guard"
     },
     "Terminal": {
       "type": "Terminal",
@@ -37,20 +37,6 @@
       "direct_transition": "Measurement_Period_Guard",
       "name": "IPP_Age_Guard"
     },
-    "Set_Measurement_Period_Start": {
-      "type": "SetAttribute",
-      "attribute": "Start of Measurement Period",
-      "direct_transition": "Set_Measurement_Period_End",
-      "name": "Set_Measurement_Period_Start",
-      "value": "2019-01-01T00:00:00Z"
-    },
-    "Set_Measurement_Period_End": {
-      "type": "SetAttribute",
-      "attribute": "End of Measurement Period",
-      "direct_transition": "IPP_Age_Guard",
-      "name": "Set_Measurement_Period_End",
-      "value": "2019-12-31T00:00:00Z"
-    },
     "Measurement_Period_Guard": {
       "type": "Guard",
       "remarks": [
@@ -59,7 +45,7 @@
       "allow": {
         "condition_type": "Date",
         "operator": ">=",
-        "attribute": "Start of Measurement Period"
+        "year": 2019
       },
       "distributed_transition": [
         {
@@ -90,18 +76,8 @@
           "value_set": ""
         }
       ],
-      "assign_to_attribute": "has_diabetes",
-      "distributed_transition": [
-        {
-          "transition": "IPP_Qualifying_Encounter",
-          "distribution": 0.75
-        },
-        {
-          "transition": "Check_Population",
-          "distribution": 0.25
-        }
-      ],
-      "name": "Diagnose_Diabetes"
+      "name": "Diagnose_Diabetes",
+      "direct_transition": "Set_Has_Diabetes"
     },
     "IPP_Qualifying_Encounter": {
       "type": "Encounter",
@@ -288,6 +264,22 @@
         }
       ],
       "name": "Set_Encounter_Occurred",
+      "value": true
+    },
+    "Set_Has_Diabetes": {
+      "type": "SetAttribute",
+      "attribute": "has_diabetes",
+      "distributed_transition": [
+        {
+          "transition": "IPP_Qualifying_Encounter",
+          "distribution": 0.75
+        },
+        {
+          "transition": "Check_Population",
+          "distribution": 0.25
+        }
+      ],
+      "name": "Set_Has_Diabetes",
       "value": true
     }
   },

--- a/src/main/resources/modules/CMS122-v10.json
+++ b/src/main/resources/modules/CMS122-v10.json
@@ -1,0 +1,135 @@
+{
+  "name": "CMS122-v10.json",
+  "remarks": [
+    "Module based on CMS122v10 - Hemoglobin A1c Poor Control (>9%)"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Set_Measurement_Period_Start",
+      "name": "Initial"
+    },
+    "Terminal": {
+      "type": "Terminal",
+      "name": "Terminal"
+    },
+    "IPP_Age_Guard": {
+      "type": "Guard",
+      "allow": {
+        "condition_type": "And",
+        "conditions": [
+          {
+            "condition_type": "Age",
+            "operator": ">=",
+            "quantity": 18,
+            "unit": "years",
+            "value": 0
+          },
+          {
+            "condition_type": "Age",
+            "operator": "<=",
+            "quantity": 75,
+            "unit": "years",
+            "value": 0
+          }
+        ]
+      },
+      "direct_transition": "Measurement_Period_Guard",
+      "name": "IPP_Age_Guard"
+    },
+    "Set_Measurement_Period_Start": {
+      "type": "SetAttribute",
+      "attribute": "Start of Measurement Period",
+      "direct_transition": "Set_Measurement_Period_End",
+      "name": "Set_Measurement_Period_Start",
+      "value": "2019-01-01T00:00:00Z"
+    },
+    "Set_Measurement_Period_End": {
+      "type": "SetAttribute",
+      "attribute": "End of Measurement Period",
+      "direct_transition": "IPP_Age_Guard",
+      "name": "Set_Measurement_Period_End",
+      "value": "2019-12-31T00:00:00Z"
+    },
+    "Measurement_Period_Guard": {
+      "type": "Guard",
+      "remarks": [
+        "Enforce measurement period"
+      ],
+      "allow": {
+        "condition_type": "Date",
+        "operator": ">=",
+        "attribute": "Start of Measurement Period"
+      },
+      "direct_transition": "Diagnose_Diabetes",
+      "name": "Measurement_Period_Guard"
+    },
+    "Diagnose_Diabetes": {
+      "type": "ConditionOnset",
+      "condition_type": "Active Condition",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "44054006",
+          "display": "Diabetes Type 2",
+          "value_set": ""
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "46635009",
+          "display": "Diabetes Type 1",
+          "value_set": ""
+        }
+      ],
+      "assign_to_attribute": "has_diabetes",
+      "direct_transition": "IPP_Qualifying_Encounter",
+      "name": "Diagnose_Diabetes"
+    },
+    "IPP_Qualifying_Encounter": {
+      "type": "Encounter",
+      "telemedicine_possibility": "none",
+      "direct_transition": "Terminal",
+      "name": "IPP_Qualifying_Encounter",
+      "codes": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "185464004",
+          "display": "Out of hours visit - not night visit (procedure)",
+          "value_set": ""
+        },
+        {
+          "system": "http://snomed.info/sct",
+          "code": "444971000124105",
+          "display": "Annual wellness visit (procedure)",
+          "value_set": ""
+        },
+        {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99397",
+          "display": "",
+          "value_set": ""
+        },
+        {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99387",
+          "display": "",
+          "value_set": ""
+        },
+        {
+          "system": "http://snomed.info/sct",
+          "code": "704126008",
+          "display": "Home visit for anticoagulant drug monitoring (procedure)",
+          "value_set": ""
+        },
+        {
+          "system": "http://snomed.info/sct",
+          "code": "386472008",
+          "display": "Telephone consultation (procedure)",
+          "value_set": ""
+        }
+      ],
+      "encounter_class": "inpatient"
+    }
+  },
+  "gmf_version": 2
+}

--- a/src/main/resources/modules/CMS122-v10.json
+++ b/src/main/resources/modules/CMS122-v10.json
@@ -88,7 +88,7 @@
     "IPP_Qualifying_Encounter": {
       "type": "Encounter",
       "telemedicine_possibility": "none",
-      "direct_transition": "Terminal",
+      "direct_transition": "Set_IPP",
       "name": "IPP_Qualifying_Encounter",
       "codes": [
         {
@@ -129,6 +129,48 @@
         }
       ],
       "encounter_class": "inpatient"
+    },
+    "Set_IPP": {
+      "type": "SetAttribute",
+      "attribute": "ecqm_ipp",
+      "direct_transition": "Set_Denominator",
+      "value": true,
+      "name": "Set_IPP"
+    },
+    "Set_Denominator": {
+      "type": "SetAttribute",
+      "attribute": "ecqm_denominator",
+      "value": true,
+      "direct_transition": "Record_HbA1C",
+      "name": "Set_Denominator"
+    },
+    "Record_HbA1C": {
+      "type": "Observation",
+      "vital_sign": "Blood Glucose",
+      "category": "laboratory",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "4548-4",
+          "display": "Hemoglobin A1c/Hemoglobin.total in Blood",
+          "value_set": ""
+        },
+        {
+          "system": "LOINC",
+          "code": "17856-6",
+          "display": "Hemoglobin A1c/Hemoglobin.total in Blood by HPLC",
+          "value_set": ""
+        },
+        {
+          "system": "LOINC",
+          "code": "4549-2",
+          "display": "Hemoglobin A1c/Hemoglobin.total in Blood by Electrophoresis",
+          "value_set": ""
+        }
+      ],
+      "unit": "%",
+      "direct_transition": "Terminal",
+      "name": "Record_HA1C"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/CMS122-v10.json
+++ b/src/main/resources/modules/CMS122-v10.json
@@ -210,15 +210,16 @@
                 "condition_type": "Or",
                 "conditions": [
                   {
-                    "condition_type": "Attribute",
-                    "attribute": "Blood Glucose",
+                    "condition_type": "Vital Sign",
+                    "vital_sign": "Blood Glucose",
                     "operator": ">=",
                     "value": 9
                   },
                   {
                     "condition_type": "Attribute",
-                    "attribute": "Blood Glucose",
-                    "operator": "is nil"
+                    "attribute": "HbA1c_not_performed",
+                    "operator": "==",
+                    "value": true
                   }
                 ]
               }

--- a/src/main/resources/modules/CMS122-v10.json
+++ b/src/main/resources/modules/CMS122-v10.json
@@ -61,7 +61,16 @@
         "operator": ">=",
         "attribute": "Start of Measurement Period"
       },
-      "direct_transition": "Diagnose_Diabetes",
+      "distributed_transition": [
+        {
+          "transition": "Diagnose_Diabetes",
+          "distribution": 0.75
+        },
+        {
+          "transition": "Check_Population",
+          "distribution": 0.25
+        }
+      ],
       "name": "Measurement_Period_Guard"
     },
     "Diagnose_Diabetes": {
@@ -82,7 +91,16 @@
         }
       ],
       "assign_to_attribute": "has_diabetes",
-      "direct_transition": "IPP_Qualifying_Encounter",
+      "distributed_transition": [
+        {
+          "transition": "IPP_Qualifying_Encounter",
+          "distribution": 0.75
+        },
+        {
+          "transition": "Check_Population",
+          "distribution": 0.25
+        }
+      ],
       "name": "Diagnose_Diabetes"
     },
     "IPP_Qualifying_Encounter": {
@@ -128,16 +146,7 @@
         }
       ],
       "encounter_class": "inpatient",
-      "distributed_transition": [
-        {
-          "transition": "Record_HbA1c",
-          "distribution": 0.75
-        },
-        {
-          "transition": "Set_HbA1c_Not_Performed",
-          "distribution": 0.25
-        }
-      ]
+      "direct_transition": "Set_Encounter_Occurred"
     },
     "Record_HbA1c": {
       "type": "Observation",
@@ -165,35 +174,12 @@
       ],
       "unit": "%",
       "name": "Record_HbA1c",
-      "conditional_transition": [
-        {
-          "transition": "Set_Numerator",
-          "condition": {
-            "condition_type": "Or",
-            "conditions": [
-              {
-                "condition_type": "Attribute",
-                "attribute": "Blood Glucose",
-                "operator": ">=",
-                "value": 9
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "Blood Glucose",
-                "operator": "is nil"
-              }
-            ]
-          }
-        },
-        {
-          "transition": "Set_Denominator"
-        }
-      ]
+      "direct_transition": "Check_Population"
     },
     "Set_HbA1c_Not_Performed": {
       "type": "SetAttribute",
       "attribute": "HbA1c_not_performed",
-      "direct_transition": "Set_Numerator",
+      "direct_transition": "Check_Population",
       "name": "Set_HbA1c_Not_Performed",
       "value": true
     },
@@ -217,6 +203,92 @@
       "direct_transition": "Terminal",
       "value": true,
       "name": "Set_IPP"
+    },
+    "Check_Population": {
+      "type": "Simple",
+      "name": "Check_Population",
+      "conditional_transition": [
+        {
+          "transition": "Set_Numerator",
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              {
+                "condition_type": "And",
+                "conditions": [
+                  {
+                    "condition_type": "Attribute",
+                    "attribute": "has_diabetes",
+                    "operator": "==",
+                    "value": true
+                  },
+                  {
+                    "condition_type": "Attribute",
+                    "attribute": "encounter_occurred",
+                    "operator": "==",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "condition_type": "Or",
+                "conditions": [
+                  {
+                    "condition_type": "Attribute",
+                    "attribute": "Blood Glucose",
+                    "operator": ">=",
+                    "value": 9
+                  },
+                  {
+                    "condition_type": "Attribute",
+                    "attribute": "Blood Glucose",
+                    "operator": "is nil"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "transition": "Set_Denominator",
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              {
+                "condition_type": "Attribute",
+                "attribute": "has_diabetes",
+                "operator": "==",
+                "value": true
+              },
+              {
+                "condition_type": "Attribute",
+                "attribute": "encounter_occurred",
+                "operator": "==",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "transition": "Terminal"
+        }
+      ]
+    },
+    "Set_Encounter_Occurred": {
+      "type": "SetAttribute",
+      "attribute": "encounter_occurred",
+      "distributed_transition": [
+        {
+          "transition": "Record_HbA1c",
+          "distribution": 0.75
+        },
+        {
+          "transition": "Set_HbA1c_Not_Performed",
+          "distribution": 0.25
+        }
+      ],
+      "name": "Set_Encounter_Occurred",
+      "value": true
     }
   },
   "gmf_version": 2

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -17,7 +17,7 @@ exporter.fhir_dstu2.export = false
 exporter.fhir.use_shr_extensions = false
 exporter.fhir.use_us_core_ig = true
 exporter.fhir.transaction_bundle = true
-exporter.fhir.bulk_data = false
+exporter.fhir.bulk_data = true
 # included_ and excluded_resources list out the resource types to include/exclude in the csv exporters.
 # only one of these may be set at a time, if both are set then both will be ignored.
 # if neither is set, then all resource types will be included.


### PR DESCRIPTION
# Summary
Adds a Synthea module that simulates the [CMS122 (v10)](https://ecqi.healthit.gov/ecqm/ec/2022/cms122v10) measure on our Synthea fork.

## Details
* Added [Keep Patients Modules](https://github.com/synthetichealth/synthea/wiki/Keep-Patients-Module) that flag the populations that the simulated patient falls under. The keep modules will filter the patient records that are exported. This will allow us to only generate numerator/denominator/IPP patients for measure modules.
* Adds CMS122 Synthea module as `CMS122-v10.json`. This JSON module is based off version 10 of the [eCQI definition of the CMS122 eCQM](https://ecqi.healthit.gov/ecqm/ec/2022/cms122v10).

## Open Questions/Future Work
* Do we care about including denominator exclusion criteria? I’m not sure how important it is for generating the patient data that we want to eventually test (exclusion criteria includes patients receiving palliative care, patients 66+ with an indication of frailty or living long term in an institution, and patients in hospice care during the measurement period)
* Is HbA1c recorded correctly within the module? Can it be recorded as Blood Glucose (which is how it is recorded in the [existing diabetes modules](https://github.com/synthetichealth/synthea/issues/336))?
* Is there a source we can use to find out the relative distributions of diabetes diagnosis vs. not (and HbA1c recorded vs. not)? Everything has been initialized to a 75/25 split for convenience

## Testing Guidance
* Go into `synthea.properties` within `synthea/src/main/resources` and edit `generate.log_patients.detail` to be `detailed` instead of `simple`. This will allow you to see the states reached by the Synthea patient from the terminal.
* Run `./run_synthea` with `-m “CMS122*”` and however many patients you want to generate (I recommend keeping this number low when logging detailed results). The results will be stored in `output/fhir`.
    * Run with the `-k` flag to test the keep modules and that we are hitting the right logic for each population.
    * Example: `./run_synthea -m “CMS122*” -p 1 -k "src/main/resources/keep_modules/keep_ipp.json" -a 18-75` (age flag included to avoid timeout errors for not being able to generate patients with the IPP conditions)
    * Denom/IPP patient should have diabetes and an encounter within the measurement period. Numer patients should additionally have a most recent HbA1c > 9.0% (or value of HbA1c was missing/not performed)
* Note we can also set the bulk data property within `synthea.properties` to true in order to export ndjson
